### PR TITLE
Add testing branch name to slack title

### DIFF
--- a/upload-test-result-1.0/README.md
+++ b/upload-test-result-1.0/README.md
@@ -17,6 +17,7 @@ This action will:
 | JUNIT_TEST_RESULTS  | build/test-results/test                        | Path (relative to workspce directory) to JUnit report         | Y |
 | JACOCO_REPORTS  | build/reports/jacoco/test/jacocoTestReport.xml | File Path (relative to workspce directory) to Coverage report | Y*         |
 | SLACK_URL  | https://hooks.slack.com/services/XXXXXXXXXXXXX | Slack Incomming Webhook URL                                   | Y          |
+| SOURCE_BRANCH  | master/dev/feature/xxx                         | Git branch                                                    | Y*          |
 
 ## Sample Workflow section
 ```
@@ -26,6 +27,7 @@ This action will:
         JUNIT_TEST_RESULTS: build/test-results/test
         JACOCO_REPORTS: build/reports/jacoco/test/jacocoTestReport.xml
         SLACK_URL: ${{ secrets.SLACK_URL }}
+        SOURCE_BRANCH: ${{ github.ref_name }}
 ```
 
 # Slack message example

--- a/upload-test-result-1.0/app/script.py
+++ b/upload-test-result-1.0/app/script.py
@@ -17,7 +17,7 @@ def main():
 
     # Notify to Slack
     if len(junit_report.keys()) > 0:
-        junit_msg = get_slack_junit_message(REPORT_TITLE, junit_report)
+        junit_msg = get_slack_junit_message(REPORT_TITLE, SOURCE_BRANCH, junit_report)
         send_message(SLACK_URL, junit_msg)
 
     if len(jacoco_report.keys()) > 0:

--- a/upload-test-result-1.0/app/settings.py
+++ b/upload-test-result-1.0/app/settings.py
@@ -11,6 +11,7 @@ APP_VERSION = '1.0.0'
 JUNIT_MERGE_FILES = 'junit_merge.xml'
 JUNIT_TEST_RESULTS = os.getenv('JUNIT_TEST_RESULTS', "build/test-results/test")
 JACOCO_REPORTS = os.getenv("JACOCO_REPORTS", "build/reports/jacoco/test/jacocoTestReport.xml")
+SOURCE_BRANCH = os.getenv("SOURCE_BRANCH", "")
 SLACK_URL = os.getenv("SLACK_URL", "")
 REPORT_TITLE = os.getenv('REPORT_TITLE', "자동화테스트 결과 알림")
 

--- a/upload-test-result-1.0/app/utils/junit_utils.py
+++ b/upload-test-result-1.0/app/utils/junit_utils.py
@@ -106,15 +106,18 @@ def get_junit_result(xml_file):
     return tree
 
 
-def get_slack_junit_message(title, reports):
+def get_slack_junit_message(title, branch, reports):
     template_rule = dict()
     template_rule['failures'] = 'TEMPLATE_FAILED'
     template_rule['tests'] = 'TEMPLATE_TESTED'
     template_rule['skipped'] = 'TAMPLATE_SKIPPED'
     template_rule['time'] = 'TEMPLATE_TIME'
 
+    merge_title = title
+    if len(branch) > 0:
+        merge_title = "{} - ({})".format(title, branch)
     slack_message = template_junit_msg
-    slack_message = slack_message.replace('TEMPLATE_TITLE', title)
+    slack_message = slack_message.replace('TEMPLATE_TITLE', merge_title)
     if reports['failures'] != '0':
         slack_message = slack_message.replace('TEMPLATE_RESULT', 'Fail')
         slack_message = slack_message.replace('TEMPLATE_COLOR', '#DC143C')


### PR DESCRIPTION
Github Action통해서 Unit Test결과 리포팅할 때 Branch 이름 보여줄 수 있도록 환경변수 추가